### PR TITLE
chore: fix 'conformance' check

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -27,6 +27,7 @@ policies:
     spec:
       skipPaths:
         - .git/
+        - testdata/
       includeSuffixes:
         - .go
       header: |

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ unit-tests-race: ## Performs unit tests with race detection enabled.
 
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
-	docker run --rm -it -v $(PWD):/src -w /src docker.io/autonomy/conform:v0.1.0-alpha.19
+	docker run --rm -it -v $(PWD):/src -w /src docker.io/autonomy/conform:v0.1.0-alpha.19-5-g6e0c294
 
 .PHONY: login
 login: ## Logs in to the configured container registry.


### PR DESCRIPTION
Pull down new `conform` version to ignore properly `.go` files in
`testdata/` directories.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>